### PR TITLE
fix: properly store sumup api errors in the OrderPayment info

### DIFF
--- a/pretix_sumup/payment.py
+++ b/pretix_sumup/payment.py
@@ -1,4 +1,5 @@
 import logging
+import json
 from collections import OrderedDict
 from decimal import Decimal
 from django import forms
@@ -107,7 +108,7 @@ class SumUp(BasePaymentProvider):
             payment.save()
         except Exception as err:
             internal_exception_message = f"Error while creating SumUp checkout: {err}"
-            payment.fail(info=internal_exception_message)
+            payment.fail(info=json.dumps({"error": internal_exception_message}))
             logger.exception(internal_exception_message)
             raise PaymentException(_("Error while creating SumUp checkout"))
 


### PR DESCRIPTION
Pretix base always assumes that the OrderPayment.info contains valid json even though the field is a plain text field.
This change fixes the error handling for SumUp API errors to also store a valid json in the payment info field as otherwise pretix base will produce internal errors due to a failing json parse of the OrderPayment.info field.

The pretix base code automatically performs a json load for any access into the `info_data` field of an `OrderPayment`.
```py
class OrderPayment(models.Model):
    # ... snip ...
    @property
    def info_data(self):
        """
        This property allows convenient access to the data stored in the ``info``
        attribute by automatically encoding and decoding the content as JSON.
        """
        return json.loads(self.info) if self.info else {}
```

This in combination with the handling in this plugins payment templat rendering where we directly access the `payment.info_data` field leads to a json parse error for any payment where there was a sumup api error, e.g. due to a network error.

```py
class SumUp(BasePaymentProvider):
    # ... snip ...
    def payment_control_render(self, order: Order, payment: OrderPayment):
        transaction = payment.info_data.get("sumup_transaction")
        if not transaction:
            return ""

        return get_template("pretix_sumup/control.html").render(
            {
                "card_type": transaction["card"]["type"],
                "card_last_4_digit": transaction["card"]["last_4_digits"],
                "receipt_url": self._build_receipt_url(transaction),
            }
        )

```